### PR TITLE
Fix/ Use info route to fetch group id

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -42,12 +42,12 @@ class Client:
         self._fetch_group_id()
 
     def _fetch_group_id(self):
-        url = f"{self.endpoints.account}/api/v1/apikeys"
+        url = f"{self.endpoints.account}/api/v1/auth/info"
         data = self._request(
             "GET",
             url,
         )
-        self.group_id = data["data"][0]["group"]["id"]
+        self.group_id = data["data"]["group_id"]
 
     def _login(self):
         url = f"{self.endpoints.account}/api/v1/auth/login"


### PR DESCRIPTION
API Keys permissions have been restricted and it is no longer possible to retrieve the list of api keys using a given api key, so this endpoint cannot be queried to retrieve the group_id. Use the more natural /auth/info instead