### PR TITLE
Fix/ Add option to fetch job results in get_jobs

### DIFF
--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -57,11 +57,12 @@ class SDK:
         self.batches[batch.id] = batch
         return batch
 
-    def get_batch(self, id) -> Batch:
+    def get_batch(self, id: int, load_results: bool = False) -> Batch:
         """Retrieve a batch's data and all its jobs.
 
         Args:
             id: Id of the batch.
+            load_results: whether to load job results
 
         Returns:
             Batch: the batch stored in the PCS database.
@@ -70,7 +71,7 @@ class SDK:
         batch_rsp = self._client._get_batch(id)
         batch = Batch(**batch_rsp, _client=self._client)
 
-        job_rsp = self._client._get_jobs(id)
+        job_rsp = self._client._get_jobs(id, fetch_results=load_results)
         for job in job_rsp:
             batch.jobs[job["id"]] = Job(**job)
 

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -96,7 +96,7 @@ class Batch:
             while rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
                 rsp = self._client._get_batch(self.id)
-            jobs_rsp = self._client._get_jobs(self.id)
+            jobs_rsp = self._client._get_jobs(self.id, fetch_results=True)
             for j in jobs_rsp:
                 job = Job(**j)
                 self.jobs[job.id] = job

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -126,10 +126,17 @@ class Client:
             "data"
         ]
 
-    def _get_jobs(self, batch_id: int) -> List:
-        return self._request(
+    def _get_jobs(self, batch_id: int, fetch_results: bool = False) -> List:
+        job_list = self._request(
             "GET", f"{self.endpoints.core}/api/v1/jobs?batch_id={batch_id}"
         )["data"]
+        # Job results are not included when fetching a list of jobs
+        # Fetch them explicitly if wanted
+        if fetch_results:
+            for job_data in job_list:
+                if job_data.get("status") == "DONE":
+                    job_data["result"] = self._get_job(job_data["id"]).get("result")
+        return job_list
 
     def _get_job(self, job_id: int) -> Dict:
         return self._request("GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}")[

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -11,10 +11,10 @@ class Job:
         - created_at: Timestamp of the creation of the batch.
         - updated_at: Timestamps of the last update of the batch.
         - batch_id: Id of the batch which the job belongs to.
-        - result: Result of the job.
         - errors: Error messages that occured while processing job.
         - id: Unique identifier for the batch
         - status: Status of the job
+        - result(optional): Result of the job.
         - variables (optional): dictionnary of variables of the job.
             None if the associated batch is non-parametrized
     """
@@ -23,8 +23,8 @@ class Job:
     batch_id: int
     id: int
     status: str
-    result: str
     created_at: str
     updated_at: str
     errors: List[str]
+    result: str = None
     variables: Dict = None


### PR DESCRIPTION
Results are no longer exposed in the API when fetching a job list to save bandwidth. They need to be retrieved by querying each job successively. 
I added an option to fetch the results in the _get_jobs method. By default when a user waits for the results after declaring a batch as complete, fetch the job results. 