### PR TITLE
Feat/ Replace explicit device_type for batch creation by optional emulator flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -e .
 ```
 
 Bear in mind that this installation will track the contents of your local
-cloud_sdk repository folder, so if you checkout a different branch (e.g. ``master``),
+cloud_sdk repository folder, so if you checkout a different branch (e.g. `master`),
 your installation will change accordingly.
 
 ### Development Requirements (Optional)
@@ -31,16 +31,16 @@ pip install -e .[dev]
 
 ## Basic usage
 
-The package main component is a python object called `SDK` which can be used to create a `Batch` and send it automatically 
+The package main component is a python object called `SDK` which can be used to create a `Batch` and send it automatically
 to Pasqal APIs using an API token generated in the [user portal](https://pasqal.cloud.io) (available soon).
 
-A `Batch` is a group of jobs with the same sequence that run on the same QPU. 
-The batch sequence can be generated using [Pulser](https://github.com/pasqal-io/Pulser). See their [documentation](https://pulser.readthedocs.io/en/stable/), 
+A `Batch` is a group of jobs with the same sequence that run on the same QPU.
+The batch sequence can be generated using [Pulser](https://github.com/pasqal-io/Pulser). See their [documentation](https://pulser.readthedocs.io/en/stable/),
 for more information on how to install the library and create your own sequence.
 
 ```python
 from sdk import SDK
-from pulser import devices, Register, Sequence 
+from pulser import devices, Register, Sequence
 
 client_id="your_client_id" # Replace this value by the client id of your API key
 client_secret="your_client_secret" #Replace this value by the client secret of your API key
@@ -56,6 +56,8 @@ serialized_sequence = sequence.serialize() # Serialize the sequence in json form
 
 # Create a new batch and send it to Pasqal QPUs
 batch = sdk.create_batch(serialized_sequence)
+# You can also choose to run your batch on an emulator using the optional argument 'emulator'
+# batch = sdk.create_batch(serialized_sequence, emulator=True)
 
 # Add jobs to your batch
 job1 = batch.add_job(runs=400)

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sdk.batch import Batch, DeviceType
+from sdk.batch import Batch
 from sdk.client import Client
 from sdk.endpoints import Endpoints
 from sdk.job import Job
@@ -35,13 +35,15 @@ class SDK:
     def create_batch(
         self,
         serialized_sequence: str,
-        device_type: DeviceType = DeviceType.EMULATOR,
+        emulator: bool = False,
     ) -> Batch:
         """Create a new batch and send it to the API.
 
         Args:
             serialized_sequence: Serialized pulser sequence.
-            device_type: Type of device to run the batch on.
+            emulator: Whether to run the batch on an emulator.
+              If set to false, the device_type will be set to the one
+              stored in the serialized sequence
 
         Returns:
             Batch: The new batch that has been created in the database.
@@ -49,7 +51,7 @@ class SDK:
         batch_rsp = self._client._send_batch(
             {
                 "sequence_builder": serialized_sequence,
-                "device_type": device_type,
+                "emulator": emulator,
                 "webhook": self.webhook,
             }
         )

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -4,12 +4,6 @@ from typing import Dict
 
 from sdk.client import Client
 from sdk.job import Job
-from sdk.utils.enum import StrEnum
-
-
-class DeviceType(StrEnum):
-    EMULATOR = "EMULATOR"
-    MOCK = "MOCK_DEVICE"
 
 
 RESULT_POLLING_INTERVAL = 2  # seconds

--- a/sdk/utils/enum.py
+++ b/sdk/utils/enum.py
@@ -1,7 +1,0 @@
-from enum import Enum
-
-
-class StrEnum(str, Enum):
-    def __str__(self):
-        """Used when dumping enum fields in a schema."""
-        return self.value


### PR DESCRIPTION
Pasqal Cloud Services do not expect anymore the device type to create a batch. It is now extracted automatically from the serialized pulser sequence. An optional emulator flag gives the ability to the user to select to run the batch on an emulator instead of a real QPU.

- Feat/ Replace explicit device_type for batch creation by optional emulator flag
- Doc/ Update basic usage in Readme