### PR TITLE
Update batch arguments

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -31,7 +31,7 @@ class Batch:
         - sequence_builder: Pulser sequence of the batch
         - jobs: Dictionnary of all the jobs added to the batch.
         - jobs_count: number of jobs added to the batch
-        - pending_jobs_count: number of jobs that have not been processed yet
+        - jobs_count_per_status: number of jobs per status
     """
 
     complete: bool
@@ -48,7 +48,7 @@ class Batch:
     sequence_builder: str
     jobs: Dict[int, Job] = field(default_factory=dict)
     jobs_count: int = 0
-    pending_jobs_count: int = 0
+    jobs_count_per_status: dict = {}
 
     def add_job(self, runs: int = 100, variables: Dict = None, wait: bool = False):
         """Add and send a new job for this batch.


### PR DESCRIPTION
Following the change of `pending_jobs_count` to `jobs_count_per_status` on `public-apis`, this updates the SDK batch definition.