### PR TITLE
Fix: Default dict specification

### DIFF
--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -48,7 +48,7 @@ class Batch:
     sequence_builder: str
     jobs: Dict[int, Job] = field(default_factory=dict)
     jobs_count: int = 0
-    jobs_count_per_status: dict = {}
+    jobs_count_per_status: Dict[str, int] = field(default_factory=dict)
 
     def add_job(self, runs: int = 100, variables: Dict = None, wait: bool = False):
         """Add and send a new job for this batch.


### PR DESCRIPTION
Specifying an empty dict as default does not work for dataclasses.