### PR TITLE
Feat / update sdk for iroise

### DIFF
--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sdk.batch import Batch
+import time
+from typing import List
+
+from sdk.batch import Batch, RESULT_POLLING_INTERVAL
 from sdk.client import Client
 from sdk.endpoints import Endpoints
 from sdk.job import Job
@@ -35,28 +38,44 @@ class SDK:
     def create_batch(
         self,
         serialized_sequence: str,
+        jobs: List[Job],
         emulator: bool = False,
+        wait: bool = False,
     ) -> Batch:
         """Create a new batch and send it to the API.
+        For Iroise MVP, the batch must contain at least one job and will be declared as complete immediately.
 
         Args:
             serialized_sequence: Serialized pulser sequence.
+            jobs: List of jobs to be added to the batch at creation. (#TODO: Make optional after Iroise MVP)
             emulator: Whether to run the batch on an emulator.
               If set to false, the device_type will be set to the one
               stored in the serialized sequence
+            wait: Whether to wait for results to be sent back
+
 
         Returns:
             Batch: The new batch that has been created in the database.
         """
-        batch_rsp = self._client._send_batch(
+        batch_rsp, jobs_rsp = self._client._send_batch(
             {
                 "sequence_builder": serialized_sequence,
                 "emulator": emulator,
                 "webhook": self.webhook,
+                "jobs": [job.__dict__ for job in jobs],
             }
         )
         batch = Batch(**batch_rsp, _client=self._client)
+        for job_rsp in jobs_rsp:
+            batch.jobs[job_rsp["id"]] = Job(**job_rsp)
         self.batches[batch.id] = batch
+        if wait:
+            while batch_rsp["status"] in ["PENDING", "RUNNING"]:
+                time.sleep(RESULT_POLLING_INTERVAL)
+                batch_rsp = self._client._get_batch(batch.id)
+            for job_id, job in batch.jobs.items():
+                job_rsp = self._client._get_job(job_id)
+                batch.jobs[job.id] = Job(**job_rsp)
         return batch
 
     def get_batch(self, id: int, load_results: bool = False) -> Batch:

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-from typing import List
+from typing import Any, Dict, List
 
 from sdk.batch import Batch, RESULT_POLLING_INTERVAL
 from sdk.client import Client
@@ -38,7 +38,7 @@ class SDK:
     def create_batch(
         self,
         serialized_sequence: str,
-        jobs: List[Job],
+        jobs: List[Dict[str, Any]],
         emulator: bool = False,
         wait: bool = False,
     ) -> Batch:
@@ -62,7 +62,7 @@ class SDK:
                 "sequence_builder": serialized_sequence,
                 "emulator": emulator,
                 "webhook": self.webhook,
-                "jobs": [job.__dict__ for job in jobs],
+                "jobs": jobs,
             }
         )
         batch = Batch(**batch_rsp, _client=self._client)

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -104,11 +104,13 @@ class Client:
 
     def _send_batch(self, batch_data: Dict):
         batch_data.update({"group_id": self.group_id})
-        return self._request(
+        batch_data = self._request(
             "POST",
             f"{self.endpoints.core}/api/v1/batches",
             batch_data,
         )["data"]
+        jobs_data = batch_data.pop("jobs", [])
+        return batch_data, jobs_data
 
     def _complete_batch(self, batch_id: int):
         response = self._request(

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import requests
 
@@ -102,7 +102,7 @@ class Client:
 
         return data
 
-    def _send_batch(self, batch_data: Dict):
+    def _send_batch(self, batch_data: Dict)-> Dict[str, Any], List[Dict[str,Any]]:
         batch_data.update({"group_id": self.group_id})
         batch_data = self._request(
             "POST",

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import requests
 
@@ -102,7 +102,9 @@ class Client:
 
         return data
 
-    def _send_batch(self, batch_data: Dict)-> Dict[str, Any], List[Dict[str,Any]]:
+    def _send_batch(
+        self, batch_data: Dict
+    ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         batch_data.update({"group_id": self.group_id})
         batch_data = self._request(
             "POST",

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -28,3 +28,8 @@ class Job:
     errors: List[str]
     result: str = None
     variables: Dict = None
+
+    def __init__(self, runs, **kwargs):
+        self.runs = runs
+        for field in kwargs:
+            setattr(self, field, kwargs[field])

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -28,8 +28,3 @@ class Job:
     errors: List[str]
     result: str = None
     variables: Dict = None
-
-    def __init__(self, runs, **kwargs):
-        self.runs = runs
-        for field in kwargs:
-            setattr(self, field, kwargs[field])

--- a/tests/fixtures/api/batches/_.POST.json
+++ b/tests/fixtures/api/batches/_.POST.json
@@ -1,7 +1,7 @@
 {
   "code": 200,
   "data": {
-    "complete": false,
+    "complete": true,
     "created_at": "2021-11-10T15:24:38.155824",
     "device_type": "MOCK_DEVICE",
     "group_id": 1,
@@ -11,7 +11,23 @@
     "status": "PENDING",
     "updated_at": "2021-11-10T15:27:44.110274",
     "user_id": 1,
-    "webhook": "10.0.1.5"
+    "webhook": "10.0.1.5",
+    "jobs": [{
+      "batch_id": 1,
+      "id": 22010,
+      "runs": 50,
+      "status": "PENDING",
+      "updated_at": "2021-11-10T15:27:06.698066",
+      "variables": {
+        "Omega_max": 14.4,
+        "last_target": "q1",
+        "ts": [
+          200,
+          500
+        ]
+      }
+
+    }]
   },
   "message": "OK.",
   "status": "success"

--- a/tests/fixtures/api/batches/_.POST.json
+++ b/tests/fixtures/api/batches/_.POST.json
@@ -17,6 +17,8 @@
       "id": 22010,
       "runs": 50,
       "status": "PENDING",
+      "created_at": "2021-11-10T15:27:06.698066",
+      "errors": [],
       "updated_at": "2021-11-10T15:27:06.698066",
       "variables": {
         "Omega_max": 14.4,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sdk import SDK
+from sdk.job import Job
 
 
 class TestBatch:
@@ -12,26 +13,51 @@ class TestBatch:
         self.job_result = "result"
         self.n_job_runs = 50
         self.job_id = 22010
+        self.job_variables = {"Omega_max": 14.4, "last_target": "q1", "ts": [200, 500]}
 
     def test_create_batch(self):
+        job = Job(runs=self.n_job_runs, variables=self.job_variables)
         batch = self.sdk.create_batch(
-            serialized_sequence=self.pulser_sequence,
+            serialized_sequence=self.pulser_sequence, jobs=[job]
         )
         assert batch.id == self.batch_id
         assert batch.sequence_builder == self.pulser_sequence
+        # TODO: Remove after IROISE MVP
+        assert batch.complete
+        assert batch.jobs[self.job_id].batch_id == batch.id
+        assert batch.jobs[self.job_id].runs == self.n_job_runs
 
+    def test_create_batch_and_wait_for_results(self, request_mock):
+        job = Job(runs=self.n_job_runs, variables=self.job_variables)
+        batch = self.sdk.create_batch(
+            serialized_sequence=self.pulser_sequence, jobs=[job], wait=True
+        )
+        assert batch.id == self.batch_id
+        assert batch.sequence_builder == self.pulser_sequence
+        assert batch.complete
+        assert len(batch.jobs) == 1
+        assert batch.jobs[self.job_id].runs == self.n_job_runs
+        assert request_mock.last_request.method == "GET"
+        assert (
+            request_mock.last_request.url
+            == f"{self.sdk._client.endpoints.core}/api/v1/jobs/{self.job_id}"
+        )
+        assert batch.jobs[self.job_id].result == self.job_result
+
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job(self, request_mock):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
         )
         job = batch.add_job(
             runs=self.n_job_runs,
-            variables={"Omega_max": 14.4, "last_target": "q1", "ts": [200, 500]},
+            variables=self.job_variables,
         )
         assert request_mock.last_request.json()["batch_id"] == batch.id
         assert job.batch_id == batch.id
         assert job.runs == self.n_job_runs
 
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_add_job_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
@@ -50,6 +76,7 @@ class TestBatch:
         )
         assert job.result == self.job_result
 
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_declare_complete(self):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,
@@ -58,6 +85,7 @@ class TestBatch:
         assert rsp["complete"]
         assert len(batch.jobs) == 0
 
+    @pytest.mark.skip(reason="Not enabled during Iroise MVP")
     def test_batch_declare_complete_and_wait_for_results(self, request_mock):
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -16,7 +16,7 @@ class TestBatch:
         self.job_variables = {"Omega_max": 14.4, "last_target": "q1", "ts": [200, 500]}
 
     def test_create_batch(self):
-        job = Job(runs=self.n_job_runs, variables=self.job_variables)
+        job = {"runs": self.n_job_runs, "variables": self.job_variables}
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence, jobs=[job]
         )
@@ -28,7 +28,7 @@ class TestBatch:
         assert batch.jobs[self.job_id].runs == self.n_job_runs
 
     def test_create_batch_and_wait_for_results(self, request_mock):
-        job = Job(runs=self.n_job_runs, variables=self.job_variables)
+        job = {"runs": self.n_job_runs, "variables": self.job_variables}
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence, jobs=[job], wait=True
         )


### PR DESCRIPTION
This MR updates the SDK for Iroise (following the `public-apis` [update](http://gitlab.local:30080/pcs/public-apis/-/merge_requests/109)) by:
- adding a required `jobs` argument to the `create_batch` function
- adding an optional `wait` argument to that same function in case the user wants to wait for the batch results
- updating/adding tests for new functionalities
- skipping tests for temporarily disabled functionalities (`add_job` and `complete_batch` which won't be usable since the batch will automatically be completed).
