### PR TITLE
Feat/ Retrieve job results as dict instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ batch = sdk.create_batch(serialized_sequence)
 job1 = batch.add_job(runs=400)
 job2 = batch.add_job(runs=100, wait=True) # You can wait for the job results
 
-results = job2.results # You can retrieve and post-process if wanted the results of the job
+results = job2.result # You can retrieve and post-process if wanted the results of the job
 
 # Declare your batch complete, meaning it awaits no new jobs and the QPU can proceed to next batch
 batch.declare_complete()

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.18"
+__version__ = "0.0.19"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -137,9 +137,11 @@ class Client:
         # Job results are not included when fetching a list of jobs
         # Fetch them explicitly if wanted
         if fetch_results:
+            results = self._request(
+                "GET", f"{self.endpoints.core}/api/v1/batches/{batch_id}/result"
+            )["data"]
             for job_data in job_list:
-                if job_data.get("status") == "DONE":
-                    job_data["result"] = self._get_job(job_data["id"]).get("result")
+                job_data["result"] = results.get(job_data["id"], None)
         return job_list
 
     def _get_job(self, job_id: int) -> Dict:

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -26,5 +26,5 @@ class Job:
     created_at: str
     updated_at: str
     errors: List[str]
-    result: str = None
+    result: Dict = None
     variables: Dict = None

--- a/tests/fixtures/api/jobs/22010/_.GET.json
+++ b/tests/fixtures/api/jobs/22010/_.GET.json
@@ -1,27 +1,24 @@
 {
   "code": 200,
-  "data": {  
-      "batch_id": 1,
-      "created_at": "2021-11-10T15:24:38.172109",
-      "errors": [
-        "Error 1",
-        "Error 2: Cannot connect to QPU",
-        "Error 3: Matrix glitch"
-      ],
-      "id": 22010,
-      "result": "result",
-      "runs": 50,
-      "status": "DONE",
-      "updated_at": "2021-11-10T15:27:06.698066",
-      "variables": {
-        "Omega_max": 14.4,
-        "last_target": "q1",
-        "ts": [
-          200,
-          500
-        ]
-      }
-    },
+  "data": {
+    "batch_id": 1,
+    "created_at": "2021-11-10T15:24:38.172109",
+    "errors": [
+      "Error 1",
+      "Error 2: Cannot connect to QPU",
+      "Error 3: Matrix glitch"
+    ],
+    "id": 22010,
+    "result": { "1001": 12, "0110": 35, "1111": 1 },
+    "runs": 50,
+    "status": "DONE",
+    "updated_at": "2021-11-10T15:27:06.698066",
+    "variables": {
+      "Omega_max": 14.4,
+      "last_target": "q1",
+      "ts": [200, 500]
+    }
+  },
   "message": "OK.",
   "status": "success"
 }

--- a/tests/fixtures/api/jobs/_.GET.json
+++ b/tests/fixtures/api/jobs/_.GET.json
@@ -1,7 +1,7 @@
 {
   "code": 200,
   "data": [
-    {  
+    {
       "batch_id": 1,
       "created_at": "2021-11-10T15:24:38.172109",
       "errors": [
@@ -10,17 +10,14 @@
         "Error 3: Matrix glitch"
       ],
       "id": 22010,
-      "result": "result",
+      "result": { "1001": 12, "0110": 35, "1111": 1 },
       "runs": 50,
       "status": "DONE",
       "updated_at": "2021-11-10T15:27:06.698066",
       "variables": {
         "Omega_max": 14.4,
         "last_target": "q1",
-        "ts": [
-          200,
-          500
-        ]
+        "ts": [200, 500]
       }
     }
   ],

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,7 +1,6 @@
 import pytest
 
 from sdk import SDK
-from sdk.job import Job
 
 
 class TestBatch:
@@ -10,7 +9,7 @@ class TestBatch:
         self.sdk = SDK(client_id="my_client_id", client_secret="my_client_secret")
         self.pulser_sequence = "pulser_test_sequence"
         self.batch_id = 1
-        self.job_result = "result"
+        self.job_result = {"1001": 12, "0110": 35, "1111": 1}
         self.n_job_runs = 50
         self.job_id = 22010
         self.job_variables = {"Omega_max": 14.4, "last_target": "q1", "ts": [200, 500]}


### PR DESCRIPTION
Job results are now sent in a dictionnary instead of in a string. Update the job class accordingly.

A new API endpoint has been defined to retrieve all job results for a given batch. Use that endpoint to retrieve job results when asked by the user instead of making a request for each job separately