### PR TITLE
Fix  / Device status for batch

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -46,6 +46,7 @@ class Batch:
     webhook: str
     _client: Client
     sequence_builder: str
+    device_status: str = None
     jobs: Dict[int, Job] = field(default_factory=dict)
     jobs_count: int = 0
     jobs_count_per_status: Dict[str, int] = field(default_factory=dict)

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -29,6 +29,7 @@ class Batch:
         - status: Status of the batch
         - webhook: Webhook where the job results are automatically sent to.
         - sequence_builder: Pulser sequence of the batch
+        - device_status: Status of the device where the batch is running.
         - jobs: Dictionnary of all the jobs added to the batch.
         - jobs_count: number of jobs added to the batch
         - jobs_count_per_status: number of jobs per status

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -26,6 +26,5 @@ class Job:
     created_at: str
     updated_at: str
     errors: List[str]
-    device_status: str = None
     result: str = None
     variables: Dict = None


### PR DESCRIPTION
This puts the `device_status` as a batch and not job attribute.
See failing e2e test: http://gitlab.local:30080/pcs/cloud-e2e-tests/-/pipelines/5501 