### PR TITLE
Fix / Get batch function

### DIFF
--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -72,7 +72,7 @@ class SDK:
         if wait:
             while batch_rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
-                batch_rsp = self._client._get_batch(batch.id)
+                batch_rsp, _ = self._client._get_batch(batch.id)
             for job_id, job in batch.jobs.items():
                 job_rsp = self._client._get_job(job_id)
                 batch.jobs[job.id] = Job(**job_rsp)
@@ -89,12 +89,9 @@ class SDK:
             Batch: the batch stored in the PCS database.
         """
 
-        batch_rsp = self._client._get_batch(id)
+        batch_rsp, jobs_rsp = self._client._get_batch(id, fetch_results=load_results)
         batch = Batch(**batch_rsp, _client=self._client)
-
-        job_rsp = self._client._get_jobs(id, fetch_results=load_results)
-        for job in job_rsp:
-            batch.jobs[job["id"]] = Job(**job)
-
+        for job_rsp in jobs_rsp:
+            batch.jobs[job_rsp["id"]] = Job(**job_rsp)
         self.batches[batch.id] = batch
         return batch

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -78,18 +78,18 @@ class SDK:
                 batch.jobs[job.id] = Job(**job_rsp)
         return batch
 
-    def get_batch(self, id: int, load_results: bool = False) -> Batch:
+    def get_batch(self, id: int, fetch_results: bool = False) -> Batch:
         """Retrieve a batch's data and all its jobs.
 
         Args:
             id: Id of the batch.
-            load_results: whether to load job results
+            fetch_results: whether to load job results
 
         Returns:
             Batch: the batch stored in the PCS database.
         """
 
-        batch_rsp, jobs_rsp = self._client._get_batch(id, fetch_results=load_results)
+        batch_rsp, jobs_rsp = self._client._get_batch(id, fetch_results=fetch_results)
         batch = Batch(**batch_rsp, _client=self._client)
         for job_rsp in jobs_rsp:
             batch.jobs[job_rsp["id"]] = Job(**job_rsp)

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -91,9 +91,9 @@ class Batch:
         if wait:
             while rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
-                rsp = self._client._get_batch(self.id)
-            jobs_rsp = self._client._get_jobs(self.id, fetch_results=True)
-            for j in jobs_rsp:
-                job = Job(**j)
+                rsp, _ = self._client._get_batch(self.id)
+            for job_id, job in self.jobs.items():
+                job_rsp = self._client._get_job(job_id)
+                job = Job(**job_rsp)
                 self.jobs[job.id] = job
         return rsp

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -91,9 +91,9 @@ class Batch:
         if wait:
             while rsp["status"] in ["PENDING", "RUNNING"]:
                 time.sleep(RESULT_POLLING_INTERVAL)
-                rsp, _ = self._client._get_batch(self.id)
-            for job_id, job in self.jobs.items():
-                job_rsp = self._client._get_job(job_id)
-                job = Job(**job_rsp)
-                self.jobs[job.id] = job
-        return rsp
+                batch_rsp, jobs_rsp = self._client._get_batch(
+                    self.id, fetch_results=True
+                )
+            for job_rsp in jobs_rsp:
+                self.jobs[job_rsp["id"]] = Job(**job_rsp)
+        return batch_rsp

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -125,24 +125,19 @@ class Client:
             "data"
         ]
 
-    def _get_batch(self, id: int) -> Dict:
-        return self._request("GET", f"{self.endpoints.core}/api/v1/batches/{id}")[
+    def _get_batch(self, id: int, fetch_results: bool = False) -> Dict:
+        batch_data = self._request("GET", f"{self.endpoints.core}/api/v1/batches/{id}")[
             "data"
         ]
-
-    def _get_jobs(self, batch_id: int, fetch_results: bool = False) -> List:
-        job_list = self._request(
-            "GET", f"{self.endpoints.core}/api/v1/jobs?batch_id={batch_id}"
-        )["data"]
-        # Job results are not included when fetching a list of jobs
-        # Fetch them explicitly if wanted
+        jobs_data = batch_data.pop("jobs", {})
         if fetch_results:
             results = self._request(
-                "GET", f"{self.endpoints.core}/api/v1/batches/{batch_id}/results"
+                "GET", f"{self.endpoints.core}/api/v1/batches/{id}/results"
             )["data"]
-            for job_data in job_list:
+        for job_data in jobs_data:
+            if fetch_results:
                 job_data["result"] = results.get(job_data["id"], None)
-        return job_list
+        return batch_data, jobs_data
 
     def _get_job(self, job_id: int) -> Dict:
         return self._request("GET", f"{self.endpoints.core}/api/v1/jobs/{job_id}")[

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -134,8 +134,7 @@ class Client:
             results = self._request(
                 "GET", f"{self.endpoints.core}/api/v1/batches/{id}/results"
             )["data"]
-        for job_data in jobs_data:
-            if fetch_results:
+            for job_data in jobs_data:
                 job_data["result"] = results.get(job_data["id"], None)
         return batch_data, jobs_data
 


### PR DESCRIPTION
The `get_batch` function with `load_results=True` was not working properly due to the attribute `jobs` of the `batch` object being assigned sometimes a list and sometimes a dict.
This fixes it, and also rationalizes the client functions so that there is only one way to get the batch results at once.
The end-to-end tests will be modified to include the use case that triggered this error.