### PR TITLE
Fix: HTTP errors with data = None

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.25"
+__version__ = "0.1.0"

--- a/sdk/errors.py
+++ b/sdk/errors.py
@@ -21,12 +21,17 @@ from sdk.utils.jsend import JSendPayload
 class HTTPError(Exception):
     code: int
     message: str
+    description: str
+    details: dict
 
     def __init__(self, data: JSendPayload, *args: object) -> None:
         super().__init__(*args)
         self.code = data["code"]
         # If no error description, display default response message instead
-        self.description = data.get("data", {}).get("description", data["message"])
+        if data.get("data"):
+            self.description = data["data"].get("description", data["message"])
+        else:
+            self.description = data["message"]
         self.details = data
 
     def __str__(self) -> str:


### PR DESCRIPTION
`obj.get("data", {})` returns `None` if the `data` field is explicitly set to None. the default value of `get` is used only if the key is not found in the object.

500 errors seem to return a payload with a null data, thus failing the parsing.

