### PR TITLE
[FIX] Save jobs result properly in batch object

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -135,7 +135,7 @@ class Client:
                 "GET", f"{self.endpoints.core}/api/v1/batches/{id}/results"
             )["data"]
             for job_data in jobs_data:
-                job_data["result"] = results.get(job_data["id"], None)
+                job_data["result"] = results.get(str(job_data["id"]), None)
         return batch_data, jobs_data
 
     def _get_job(self, job_id: int) -> Dict:


### PR DESCRIPTION
JSON keys are necessarily string, yet the jobs are indexed with their id as an integer, thus `results.get(job_data["id"])` was always returning None. This fixes it by casting the id to `str` when parsing the response of the request.