### PR TITLE
[FIX] Make ReadMe compatible with new emulator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ job2 = {"runs": 50, "variables": {"omega_max": 10.5} }
 # Send the batch of jobs to the QPU and wait for the results
 batch = sdk.create_batch(serialized_sequence, [job1,job2], wait=True)
 
-# You can also choose to run your batch on an emulator using the optional argument 'emulator'
-# batch = sdk.create_batch(serialized_sequence, [job1,job2], emulator=True)
+# You can also choose to run your batch on an emulator using the optional argument 'device_type'
+# For using our free emulator, you can use DeviceType.EMU_FREE
+from sdk import DeviceType
+batch = sdk.create_batch(serialized_sequence, [job1,job2], device_type=DeviceType.EMU_FREE)
 
 # Once the QPU has returned the results, you can access them with the following:
 for job in batch.jobs.values():

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"


### PR DESCRIPTION
Make users aware they should use `device_type=DeviceType.EMU_FREE`