### PR TITLE
[FIX] datetime fields for batch

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -52,8 +52,8 @@ class Batch:
     webhook: str
     _client: Client
     sequence_builder: str
-    start_datetime: str
-    end_datetime: str
+    start_datetime: Optional[str]
+    end_datetime: Optional[str]
     device_status: str = None
     jobs: Dict[int, Job] = field(default_factory=dict)
     jobs_count: int = 0

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -22,7 +22,7 @@ class Batch:
         - complete: Whether the batch has been declared as complete.
         - created_at: Timestamp of the creation of the batch.
         - updated_at: Timestamps of the last update of the batch.
-        - device_type: Type of device To run the batch on.
+        - device_type: Type of device to run the batch on.
         - group_id: Id of the owner group of the batch.
         - id: Unique identifier for the batch.
         - user_id: Unique identifier of the user that created the batch.
@@ -30,11 +30,14 @@ class Batch:
         - status: Status of the batch.
         - webhook: Webhook where the job results are automatically sent to.
         - sequence_builder: Pulser sequence of the batch.
+        - start_datetime: Timestamp of the time the batch was sent to the QPU.
+        - end_datetime: Tiemstamp of when the  batch process was finished.
         - device_status: Status of the device where the batch is running.
         - jobs: Dictionary of all the jobs added to the batch.
         - jobs_count: number of jobs added to the batch.
         - jobs_count_per_status: number of jobs per status.
         - configuration: Further configuration for certain emulators.
+
     """
 
     complete: bool
@@ -49,6 +52,8 @@ class Batch:
     webhook: str
     _client: Client
     sequence_builder: str
+    start_datetime: str
+    end_datetime: str
     device_status: str = None
     jobs: Dict[int, Job] = field(default_factory=dict)
     jobs_count: int = 0


### PR DESCRIPTION
The SDK isn't capable of performing anything that would ever create/update these two values, they would simply exist in the payload when the item exists in the DB.