### PR TITLE
[FEAT] Add start and end timestamps to jobs

### DIFF
--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -125,7 +125,7 @@ class Client:
             "data"
         ]
 
-    def _get_batch(self, id: int, fetch_results: bool = False) -> Dict:
+    def _get_batch(self, id: int, fetch_results: bool = False) -> Tuple[Dict, Dict]:
         batch_data = self._request("GET", f"{self.endpoints.core}/api/v1/batches/{id}")[
             "data"
         ]

--- a/sdk/job.py
+++ b/sdk/job.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -10,6 +10,8 @@ class Job:
         - runs: Number of time the job should be ran.
         - created_at: Timestamp of the creation of the batch.
         - updated_at: Timestamps of the last update of the batch.
+        - start_timestamp(optional): The timestamp of when the job began processing.
+        - end_timestamp(optional): The timestamp of when the job finished processing.
         - batch_id: Id of the batch which the job belongs to.
         - errors: Error messages that occured while processing job.
         - id: Unique identifier for the batch
@@ -26,5 +28,7 @@ class Job:
     created_at: str
     updated_at: str
     errors: List[str]
+    start_timestamp: Optional[str] = None
+    end_timestamp: Optional[str] = None
     result: Dict = None
     variables: Dict = None


### PR DESCRIPTION
Adds `start_` and `end_timestamp` fields onto job objects in the SDK in order to allow them to be deserialised from the response from the API.

#### Additional changes

- Fixes the type annotation on `_get_batch` as this was interfering with testing