### PR TITLE
[FEAT] Use core fast by default in the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [In progresss]
+## [0.1.13] - [In progress]
 
 ### Changed
 - The default values for the tensor network emulator were updated to better ones.
 - the client_id and client_secret was leftover in the Client object even though they are no longer used.
 - Updated the README to also supply the group_id which is mandatory.
+- Updated the default endpoint to `/core-fast` in accordance with infra changes. All users should use `/core-fast` in all environments.
 
 ## [0.1.12] - 2023-02-27
 

--- a/sdk/endpoints.py
+++ b/sdk/endpoints.py
@@ -19,9 +19,9 @@ from dataclasses import dataclass
 if version_info[:2] >= (3, 8):
     from typing import Final
 else:
-    from typing_extensions import Final # type: ignore
+    from typing_extensions import Final  # type: ignore
 
-CORE_API_URL: Final[str] = "https://apis.pasqal.cloud/core"
+CORE_API_URL: Final[str] = "https://apis.pasqal.cloud/core-fast"
 ACCOUNT_API_URL: Final[str] = "https://apis.pasqal.cloud/account"
 
 


### PR DESCRIPTION
This changes the core endpoint to use core fast as default.
This is blocked until we release core fast to production.
However, we should already  release core fast to preprod and start telling our users to switch to core fast. I'll add it to the changelog.