### PR TITLE
[FEAT] Replace EMU_SV with EMU_TN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased] - yyyy-mm-dd
-
-Here we write upgrading notes for brands. It's a team effort to make them as
-straightforward as possible.
+## [0.1.10] - 2023-02-09
 
 ### Added
 
 ### Changed
+
+- A new device type, "EMU-TN", corresponding to tensor netowrk-based emulator, was added. The "EMU_SV" type was removed as it is not available right now.
 
 - A new version of the "core" microservice, using FastAPI instead of Flask as web framework, was released in the "dev" environment. If using the "dev" environment, you should upgrade the core endpoint you are using to "https://apis.dev.pasqal.cloud/core-fast"
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ batch = sdk.create_batch(serialized_sequence, [job1,job2], wait=True)
 
 # You can also choose to run your batch on an emulator using the optional argument 'device_type'
 # For using a basic single-threaded QPU emulator that can go up to 10 qubits, you can specify the "EMU_FREE" device type.
-# "EMU_SV", which is a more performant version, is not available on this platform yet.
 from sdk import DeviceType
 batch = sdk.create_batch(serialized_sequence, [job1,job2], device_type=DeviceType.EMU_FREE)
 
@@ -93,10 +92,10 @@ for job in batch.jobs.values():
 
 ### Extra emulator configuration (Soon publicly available)
 
-Some emulators, such as EMU_SV and EMU_FREE, accept further configuration to control the emulation.
+Some emulators, such as EMU_TN and EMU_FREE, accept further configuration to control the emulation.
 This is because these emulators are more advanced numerical simulation of the quantum system.
 
-For EMU_SV:
+For EMU_TN:
 
 ```python
 # replace the corresponding section in the above code example with this to
@@ -105,7 +104,7 @@ from sdk.device.device_types import DeviceType
 from sdk.device.configuration import EmuSVConfig
 
 configuration = EmuSVConfig(dt = 0.5, precision = "normal")
-batch = sdk.create_batch(serialized_sequence, [job1,job2], device_type=DeviceType.EMU_SV, configuration=configuration)
+batch = sdk.create_batch(serialized_sequence, [job1,job2], device_type=DeviceType.EMU_TN, configuration=configuration)
 ```
 
 For EMU_FREE:

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/sdk/batch.py
+++ b/sdk/batch.py
@@ -65,8 +65,8 @@ class Batch:
         if not isinstance(self.configuration, dict):
             return
         conf_class: Type[BaseConfig] = BaseConfig
-        if self.device_type == DeviceType.EMU_SV.value:
-            conf_class = EmuSVConfig
+        if self.device_type == DeviceType.EMU_TN.value:
+            conf_class = EmuTNConfig
         elif self.device_type == DeviceType.EMU_FREE.value:
             conf_class = EmuFreeConfig
 
@@ -101,7 +101,9 @@ class Batch:
                 job = Job(**job_rsp)
         return job
 
-    def declare_complete(self, wait: bool = False, fetch_results: bool = False) -> Dict[str, Any]:
+    def declare_complete(
+        self, wait: bool = False, fetch_results: bool = False
+    ) -> Dict[str, Any]:
         """Declare to PCS that the batch is complete.
 
         Args:

--- a/sdk/device/device_types.py
+++ b/sdk/device/device_types.py
@@ -4,8 +4,8 @@ from sdk.utils.strenum import StrEnum
 class DeviceType(StrEnum):
     QPU = "QPU"
     EMU_FREE = "EMU_FREE"
-    EMU_SV = "EMU_SV"
+    EMU_TN = "EMU_TN"
 
     @property
     def configurable(self) -> bool:
-        return self in (DeviceType.EMU_FREE, DeviceType.EMU_SV)
+        return self in (DeviceType.EMU_FREE, DeviceType.EMU_TN)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -9,7 +9,7 @@ class TestBatch:
     def init_sdk(self, start_mock_request):
         self.sdk = SDK(client_id="my_client_id", client_secret="my_client_secret")
         self.pulser_sequence = "pulser_test_sequence"
-        self.batch_id = '00000000-0000-0000-0000-000000000001'
+        self.batch_id = "00000000-0000-0000-0000-000000000001"
         self.job_result = {"1001": 12, "0110": 35, "1111": 1}
         self.n_job_runs = 50
         self.job_id = "00000000-0000-0000-0000-000000022010"
@@ -35,7 +35,9 @@ class TestBatch:
         batch = self.sdk.create_batch(
             serialized_sequence=self.pulser_sequence, jobs=[job], wait=True
         )
-        assert batch.id == "00000000-0000-0000-0000-000000000001"  # the batch_id used in the mock data
+        assert (
+            batch.id == "00000000-0000-0000-0000-000000000001"
+        )  # the batch_id used in the mock data
         assert batch.sequence_builder == self.pulser_sequence
         assert batch.complete
         assert batch.jobs
@@ -47,9 +49,14 @@ class TestBatch:
     def test_create_batch_and_fetch_results(self, request_mock):
         job = {"runs": self.n_job_runs, "variables": self.job_variables}
         batch = self.sdk.create_batch(
-            serialized_sequence=self.pulser_sequence, jobs=[job], wait=True, fetch_results=True
+            serialized_sequence=self.pulser_sequence,
+            jobs=[job],
+            wait=True,
+            fetch_results=True,
         )
-        assert batch.id == "00000000-0000-0000-0000-000000000001"  # the batch_id used in the mock data
+        assert (
+            batch.id == "00000000-0000-0000-0000-000000000001"
+        )  # the batch_id used in the mock data
         assert batch.sequence_builder == self.pulser_sequence
         assert batch.complete
         assert batch.jobs
@@ -117,10 +124,18 @@ class TestBatch:
     @pytest.mark.parametrize(
         "device_type, configuration, expected",
         [
-            (DeviceType.EMU_SV, EmuSVConfig(), EmuSVConfig()),
+            (DeviceType.EMU_TN, EmuSVConfig(), EmuSVConfig()),
             (DeviceType.QPU, None, None),
-            (DeviceType.EMU_FREE, EmuFreeConfig(), EmuFreeConfig(extra_config={'dt': 0.1, 'precision': 'normal'})),
-            ('SomethingElse', BaseConfig(), BaseConfig(extra_config={'dt': 0.1, 'precision': 'normal'}))
+            (
+                DeviceType.EMU_FREE,
+                EmuFreeConfig(),
+                EmuFreeConfig(extra_config={"dt": 0.1, "precision": "normal"}),
+            ),
+            (
+                "SomethingElse",
+                BaseConfig(),
+                BaseConfig(extra_config={"dt": 0.1, "precision": "normal"}),
+            ),
         ],
     )
     def test_create_batch_configuration(self, device_type, configuration, expected):


### PR DESCRIPTION
EMU_SV is actually not finalized yet by our emulation team.
Instead, EMU_TN is now available. This updates the SDK device types accordingly.
Will open a corresponding MR in the e2e tests.