### PR TITLE
[FEAT] Allow user to directly use a JWT token instead of logging in with username / password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.13] - [In progress]
+## [0.1.13] 
 
 ### Changed
 - The default values for the tensor network emulator were updated to better ones.
 - the client_id and client_secret was leftover in the Client object even though they are no longer used.
 - Updated the README to also supply the group_id which is mandatory.
 - Updated the default endpoint to `/core-fast` in accordance with infra changes. All users should use `/core-fast` in all environments.
+- The PCS APIs Client was refactored to accept any custom token provider for authentication. This can be used by users as an alternative to the username/password-based token provider.
 
 ## [0.1.12] - 2023-02-27
 

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -28,13 +28,20 @@ class SDK:
 
     def __init__(
         self,
-        username: str,
-        password: str,
         group_id: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        login_url: Optional[str] = None,
         endpoints: Optional[Endpoints] = None,
         webhook: Optional[str] = None,
     ):
-        self._client = Client(username, password, group_id, endpoints)
+        self._client = Client(
+            username=username,
+            password=password,
+            group_id=group_id,
+            login_url=login_url,
+            endpoints=endpoints,
+        )
         self.batches: Dict[str, Batch] = {}
         self.webhook = webhook
 

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -16,7 +16,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from sdk.batch import Batch, RESULT_POLLING_INTERVAL
-from sdk.client import Client
+from sdk.client import Client, TokenProvider
 from sdk.endpoints import Endpoints
 from sdk.job import Job
 from sdk.device.configuration import BaseConfig
@@ -31,7 +31,7 @@ class SDK:
         group_id: str,
         username: Optional[str] = None,
         password: Optional[str] = None,
-        login_url: Optional[str] = None,
+        token_provider: Optional[TokenProvider] = None,
         endpoints: Optional[Endpoints] = None,
         webhook: Optional[str] = None,
     ):
@@ -39,7 +39,7 @@ class SDK:
             username=username,
             password=password,
             group_id=group_id,
-            login_url=login_url,
+            token_provider=token_provider,
             endpoints=endpoints,
         )
         self.batches: Dict[str, Batch] = {}

--- a/sdk/_version.py
+++ b/sdk/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 from sdk.endpoints import Endpoints
-from sdk.errors import HTTPError, CannotLoginError
+from sdk.errors import HTTPError, LoginError
 from sdk.utils.jsend import JSendPayload
 
 TIMEOUT = 30  # client http requests timeout after 30s
@@ -29,12 +29,16 @@ class Client:
 
     def __init__(
         self,
-        username: str,
-        password: str,
         group_id: str,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        login_url: Optional[str] = None,
         endpoints: Optional[Endpoints] = None,
-        login_url: str = "",
     ):
+        if not (username and password) and not login_url:
+            raise Exception(
+                "At least a username/password combination or an interactive login URL should be provided."
+            )
         self.username = username
         self.password = password
         self.endpoints = endpoints or Endpoints()
@@ -87,7 +91,7 @@ class Client:
         if rsp.status_code == 401:
             #  TODO: Improve the interactive login flow
             if (self.username == "" and self.password == "") and self.login_url:
-                raise CannotLoginError(
+                raise LoginError(
                     f"You cannot login without a username or password. You may want to try logging in using the interactive login flow: {self.login_url}"
                 )
             self._login()

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -46,7 +46,7 @@ class TokenProvider(Protocol):
     expiry_window: timedelta = timedelta(minutes=1.0)
 
     @abstractmethod
-    def _query_token(self) -> str:
+    def _query_token(self) -> dict[str, Any]:
         raise NotImplementedError
 
     def get_token(self) -> str:
@@ -115,8 +115,7 @@ class UsernamePasswordTokenProvider(TokenProvider):
         self.password = password
         self.login_url = login_url
 
-    def _query_token(self) -> str:
-        url = f"{self.endpoints.account}/api/v1/auth/login"
+    def _query_token(self) -> Dict[str, Any]:
         payload = {
             "email": self.username,
             "password": self.password,
@@ -134,7 +133,7 @@ class UsernamePasswordTokenProvider(TokenProvider):
         if rsp.status_code >= 400:
             raise HTTPError(data)
 
-        return data["token"]
+        return {"access_token": data["token"]}
 
 
 class Client:

--- a/sdk/client.py
+++ b/sdk/client.py
@@ -32,8 +32,8 @@ class Client:
         username: str,
         password: str,
         group_id: str,
-        login_url: str = None,
         endpoints: Optional[Endpoints] = None,
+        login_url: str = "",
     ):
         self.username = username
         self.password = password

--- a/sdk/errors.py
+++ b/sdk/errors.py
@@ -39,3 +39,7 @@ class HTTPError(Exception):
             f"Error {self.code}: {self.description}\n"
             f"Details: {json.dumps(self.details, indent=2)}"
         )
+
+
+class CannotLoginError(Exception):
+    pass

--- a/sdk/errors.py
+++ b/sdk/errors.py
@@ -41,5 +41,5 @@ class HTTPError(Exception):
         )
 
 
-class CannotLoginError(Exception):
+class LoginError(Exception):
     pass

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     url="https://github.com/pasqal-io/cloud-sdk",
-    install_requires=["requests==2.25.1", "requests-mock==1.9.3"],
+    install_requires=[
+        "requests==2.25.1",
+        "requests-mock==1.9.3",
+        "pyjwt[crypto]==2.5.0",
+    ],
     extras_require={
         "dev": {
             "black==20.8b1",
@@ -45,8 +49,10 @@ setup(
             "mypy==0.982",
             "pytest==6.2.5",
             "pytest-cov==2.11.1",
-            "types-requests==2.25.1"
+            "types-requests==2.25.1",
         },
-        ":python_version == '3.7'": ["typing-extensions==4.4.0",]
+        ":python_version == '3.7'": [
+            "typing-extensions==4.4.0",
+        ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,9 @@ JSON_FILE = "_.{}.json"
 def request_mock(mock=None):
     def mock_response(request, context):
         path = request.url.split("/api/v1/")[1].split("?")[0]
-        
+
         data = None
-        if request.method == 'POST':
+        if request.method == "POST":
             data = request.json()
 
         json_path = os.path.join(
@@ -25,7 +25,7 @@ def request_mock(mock=None):
         with open(json_path) as json_file:
             result = json.load(json_file)
             if data:
-                if data.get('emulator'):
+                if data.get("emulator"):
                     result["data"]["device_type"] = data["emulator"]
                 else:
                     result["data"]["device_type"] = DeviceType.QPU

--- a/tests/fixtures/api/auth/login/_.POST.json
+++ b/tests/fixtures/api/auth/login/_.POST.json
@@ -1,3 +1,3 @@
 {
-    "token": "my_token"
+    "data": {"token": "my_token"}
 }


### PR DESCRIPTION
This feature is needed for the Jupyter Notebook of PQD which will have the JWT token stored as an environment variable. 
Right now, it is kept as a alternative mechanism to the regular login.
In order to address the issue of token expiration, a temporary error is raised which suggests the user to perform an interactive login. Therefore, a new optional parameter is added to the SDK client, namely the `login_url` to be used.
@penguinoneshaw  let me know what you think about this implementation.