### PR TITLE
[FIX] Custom token provider documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 
 dist
 build
-venv
+venv*
 pipfile
 pipfile.lock
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3] - 2023-04-20
+
+### Fixed
+
+- Fixed bug when using a custom TokenProvider to authenticate to Pasqal Cloud Services
+
+### Changed
+- Reorder documentation for clarity
+- Clarify instructions to use a custom token provider for authentication
+
 ## [0.2.2] - 2023-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,58 @@ To run the tutorials or the test suite locally, run the following to install the
 pip install -e .[dev]
 ```
 
-## Instanciation and Authentication
+
+
+## Basic usage
+
+The package main component is a python object called `SDK` which can be used to create a `Batch` and send it automatically
+to Pasqal APIs using an API token generated in the [user portal](https://portal.pasqal.cloud).
+
+A `Batch` is a group of jobs with the same sequence that will run on the same QPU. For each job of a given batch you must set a value for each variable, if any, defined in your sequence.  
+The batch sequence can be generated using [Pulser](https://github.com/pasqal-io/Pulser). See their [documentation](https://pulser.readthedocs.io/en/stable/),
+for more information on how to install the library and create your own sequence.
+
+Once you have created your sequence, you should serialize it as follows:
+
+```python
+# sequence should be a pulser Sequence object
+serialized_sequence = sequence.to_abstract_repr()
+```
+
+Once you have serialized your sequence, you can send it with the SDK with the following code
+
+```python
+from pasqal_cloud import SDK
+from pulser import devices, Register, Sequence
+
+group_id="your_group_id" # Replace this value by your group_id on the PASQAL platform.
+username="your_username" # Replace this value by your username or email on the PASQAL platform.
+password="your_password" # Replace this value by your password on the PASQAL platform.
+
+sdk = SDK(username=username, password=password, group_id=group_id)
+
+# When creating a job, select a number of runs and set the desired values for the variables
+# defined in the sequence
+job1 = {"runs": 20, "variables": {"omega_max": 6} }
+job2 = {"runs": 50, "variables": {"omega_max": 10.5} }
+
+# Send the batch of jobs to the QPU and wait for the results
+batch = sdk.create_batch(serialized_sequence, [job1,job2], wait=True)
+
+# You can also choose to run your batch on an emulator using the optional argument 'emulator'
+# For using a basic single-threaded QPU emulator that can go up to 10 qubits, you can specify the "EMU_FREE" emulator.
+from pasqal_cloud.device import EmulatorType
+batch = sdk.create_batch(serialized_sequence, [job1,job2], emulator=EmulatorType.EMU_FREE)
+
+# Once the QPU has returned the results, you can access them with the following:
+for job in batch.jobs.values():
+    print(job.result)
+
+```
+
+## Advanced usage
+
+### Authentication
 
 There are several ways to provide a correct authentication using the SDK.
 
@@ -63,86 +114,6 @@ class CustomTokenProvider(TokenProvider):
 
 
 sdk = SDK(token_provider=CustomTokenProvider(), group_id=group_id)
-```
-
-/!\ For developers /!\
-
-If you want to redefine the APIs used by the SDK, please, do the following.
-
-```python
-from pasqal_cloud import SDK, Endpoints, Auth0COnf
-
-endpoints = Endpoints(core = "my_new_core_endpoint")
-auth0 = Auth0Conf(
-    domain="new_domain",
-    public_client_id="public_id",
-    audience="new_audience"
-)
-sdk = SDK(..., endpoints=endpoints, auth0=auth0)
-```
-
-This enables you to target backend services running locally on your machine, or other environment like preprod or dev.
-
-## Basic usage
-
-The package main component is a python object called `SDK` which can be used to create a `Batch` and send it automatically
-to Pasqal APIs using an API token generated in the [user portal](https://portal.pasqal.cloud).
-
-A `Batch` is a group of jobs with the same sequence that will run on the same QPU. For each job of a given batch you must set a value for each variable, if any, defined in your sequence.  
-The batch sequence can be generated using [Pulser](https://github.com/pasqal-io/Pulser). See their [documentation](https://pulser.readthedocs.io/en/stable/),
-for more information on how to install the library and create your own sequence.
-
-Below is an example of the creation of a simple sequence with a single variable and its serialization to a string.
-
-```python
-from pulser import devices, Pulse, Register, Sequence
-from pulser.register.special_layouts import SquareLatticeLayout
-
-# Define a register for your sequence
-register = Register.square(2, spacing=5, prefix="q")
-# Create a sequence for that register
-sequence = Sequence(register, devices.IroiseMVP)
-# Add a channel to your sequence
-sequence.declare_channel("rydberg", "rydberg_global")
-# Declare a variable
-omega_max = sequence.declare_variable("omega_max")
-# Add a pulse to that channel with the amplitude omega_max
-generic_pulse = Pulse.ConstantPulse(100, omega_max, 2, 0.0)
-sequence.add(generic_pulse, "rydberg")
-
-# When you are done building your sequence, serialize it into a string
-serialized_sequence = sequence.serialize()
-```
-
-Once you have serialized your sequence, you can send it with the SDK with the following code
-
-```python
-from pasqal_cloud import SDK
-from pulser import devices, Register, Sequence
-
-group_id="your_group_id" # Replace this value by your group_id on the PASQAL platform.
-username="your_username" # Replace this value by your username or email on the PASQAL platform.
-password="your_password" # Replace this value by your password on the PASQAL platform.
-
-sdk = SDK(username=username, password=password, group_id=group_id)
-
-# When creating a job, select a number of runs and set the desired values for the variables
-# defined in the sequence
-job1 = {"runs": 20, "variables": {"omega_max": 6} }
-job2 = {"runs": 50, "variables": {"omega_max": 10.5} }
-
-# Send the batch of jobs to the QPU and wait for the results
-batch = sdk.create_batch(serialized_sequence, [job1,job2], wait=True)
-
-# You can also choose to run your batch on an emulator using the optional argument 'emulator'
-# For using a basic single-threaded QPU emulator that can go up to 10 qubits, you can specify the "EMU_FREE" emulator.
-from pasqal_cloud.device import EmulatorType
-batch = sdk.create_batch(serialized_sequence, [job1,job2], emulator=EmulatorType.EMU_FREE)
-
-# Once the QPU has returned the results, you can access them with the following:
-for job in batch.jobs.values():
-    print(job.result)
-
 ```
 
 ### Extra emulator configuration (Soon publicly available)
@@ -184,3 +155,25 @@ sdk.get_device_specs_list()
 
 The method returns a dict object mapping a device type to a serialized device specs. These specs can be used
 to instantiate a `Device` instance in the `Pulser` library.
+
+
+### Target different API endpoints
+
+This is intended to the package developers.
+
+If you want to redefine the APIs used by the SDK, please, do the following.
+
+```python
+from pasqal_cloud import SDK, Endpoints, Auth0COnf
+
+endpoints = Endpoints(core = "my_new_core_endpoint")
+auth0 = Auth0Conf(
+    domain="new_domain",
+    public_client_id="public_id",
+    audience="new_audience"
+)
+sdk = SDK(..., endpoints=endpoints, auth0=auth0)
+```
+
+This enables you to target backend services running locally on your machine, or other environment like preprod or dev.
+

--- a/README.md
+++ b/README.md
@@ -53,22 +53,16 @@ sdk = SDK(username=username, password=password, group_id=group_id)
 sdk = SDK(username=username, group_id=group_id)
 > Please, enter your password:
 
-""" Method 3: Use a token
-    If you already know your token, you can directly pass it as an argument
-    using the following method.
+""" Method 3: Use a custom token provider
+    You can define a custom class to provide the token.
+    For example, if you know your token, you can use that token to authenticate directly to our APIs as follows.
 """
-class NewTokenProvider(TokenProvider):
-    def _query_token(self):
-        # Custom token query that will be validated by the API Calls later.
-        return {
-            "access_token": "some_token",
-            "id_token": "id_token",
-            "scope": "openid profile email",
-            "expires_in": 86400,
-            "token_type": "Bearer"
-        }
+class CustomTokenProvider(TokenProvider):
+    def get_token(self):
+        return "your-token" # Replace this value with your token
 
-sdk = SDK(token_provider=NewTokenProvider, group_id=group_id)
+
+sdk = SDK(token_provider=CustomTokenProvider(), group_id=group_id)
 ```
 
 /!\ For developers /!\

--- a/pasqal_cloud/_version.py
+++ b/pasqal_cloud/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pasqal_cloud/authentication.py
+++ b/pasqal_cloud/authentication.py
@@ -29,7 +29,7 @@ class TokenProviderError(Exception):
 
 
 class TokenProvider(ABC):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: list[Any], **kwargs: dict):
         ...
 
     @abstractmethod

--- a/pasqal_cloud/authentication.py
+++ b/pasqal_cloud/authentication.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from jwt import decode, DecodeError
-from requests import PreparedRequest
 from typing import Any, Optional
 
 from auth0.v3.authentication import GetToken  # type: ignore
-from auth0.v3.exceptions import Auth0Error  # type: ignore
+from jwt import decode, DecodeError
+from requests import PreparedRequest
 from requests.auth import AuthBase
 
 from pasqal_cloud.endpoints import Auth0Conf
@@ -30,13 +29,17 @@ class TokenProviderError(Exception):
 
 
 class TokenProvider(ABC):
+    def __init__(self, *args, **kwargs):
+        ...
+
+    @abstractmethod
+    def get_token(self) -> str:
+        raise NotImplementedError
+
+
+class ExpiringTokenProvider(TokenProvider, ABC):
     __token_cache: Optional[tuple[datetime, str]] = None
     expiry_window: timedelta = timedelta(minutes=1.0)
-
-    def __init__(self, username: str, password: str, auth0: Auth0Conf):
-        self.username = username
-        self.password = password
-        self.auth0 = auth0
 
     @abstractmethod
     def _query_token(self) -> dict[str, Any]:
@@ -99,9 +102,11 @@ class TokenProvider(ABC):
         return None
 
 
-class Auth0TokenProvider(TokenProvider):
+class Auth0TokenProvider(ExpiringTokenProvider):
     def __init__(self, username: str, password: str, auth0: Auth0Conf):
-        super().__init__(username, password, auth0)
+        self.username = username
+        self.password = password
+        self.auth0 = auth0
 
         # Makes a call in order to check the credentials at creation
         self.get_token()

--- a/pasqal_cloud/client.py
+++ b/pasqal_cloud/client.py
@@ -81,12 +81,8 @@ class Client:
 
     @staticmethod
     def _check_token_provider(token_provider: TokenProvider) -> None:
-        try:
-            # The type ignore is because I wouldn't know how to fix the type problem
-            # but the code should be correct, and is tested
-            issubclass(token_provider, TokenProvider)  # type: ignore
-        except TypeError:
-            raise TypeError("token_provider must be a TokenProvider subclass")
+        if not isinstance(token_provider, TokenProvider):
+            raise TypeError("token_provider must be an instance of TokenProvider.")
 
     def _credential_login(
         self, username: str, password: Optional[str], auth0: Auth0Conf

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     install_requires=[
         "auth0-python==3.23.1",
         "requests==2.25.1",
-        "requests-mock==1.9.3",
         "pyjwt[crypto]==2.5.0",
     ],
     extras_require={
@@ -51,6 +50,7 @@ setup(
             "pytest==6.2.5",
             "pytest-cov==2.11.1",
             "types-requests==2.25.1",
+            "requests-mock==1.9.3",
         },
         ":python_version == '3.7'": [
             "typing-extensions==4.4.0",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,9 @@
-from auth0.v3.exceptions import Auth0Error  # type: ignore
-import pytest
-
 from unittest.mock import patch
-from pasqal_cloud import SDK, Endpoints, Auth0Conf
+
+import pytest
+from auth0.v3.exceptions import Auth0Error  # type: ignore
+
+from pasqal_cloud import Auth0Conf, Endpoints, SDK
 from tests.test_doubles.authentication import (
     FakeAuth0AuthenticationFailure,
     FakeAuth0AuthenticationSuccess,
@@ -26,7 +27,10 @@ class TestAuthSuccess:
         SDK(group_id=self.group_id, username=self.username, password=self.password)
 
     def test_good_token_provider(self):
-        SDK(group_id=self.group_id, token_provider=FakeAuth0AuthenticationSuccess)
+        SDK(
+            group_id=self.group_id,
+            token_provider=FakeAuth0AuthenticationSuccess("username", "password", None),
+        )
 
     def test_correct_endpoints(self):
         sdk = SDK(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 from auth0.v3.exceptions import Auth0Error  # type: ignore
 
 from pasqal_cloud import Auth0Conf, Endpoints, SDK
+from pasqal_cloud.authentication import TokenProvider
 from tests.test_doubles.authentication import (
     FakeAuth0AuthenticationFailure,
     FakeAuth0AuthenticationSuccess,
@@ -31,6 +32,14 @@ class TestAuthSuccess:
             group_id=self.group_id,
             token_provider=FakeAuth0AuthenticationSuccess("username", "password", None),
         )
+    
+    def test_custom_token_provider(self):
+        """Test that the custom provider suggested in the readme is working"""
+        class CustomTokenProvider(TokenProvider):
+            def get_token(self):
+                return "your-token" # Replace this value with your token
+        SDK(token_provider=CustomTokenProvider(), group_id="group_id")
+
 
     def test_correct_endpoints(self):
         sdk = SDK(

--- a/tests/test_doubles/authentication.py
+++ b/tests/test_doubles/authentication.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 from typing import Any
 
 from auth0.v3.exceptions import Auth0Error
 
-from pasqal_cloud.authentication import TokenProvider
+from pasqal_cloud.authentication import Auth0TokenProvider
 
 
-class FakeAuth0AuthenticationSuccess(TokenProvider):
+class FakeAuth0AuthenticationSuccess(Auth0TokenProvider):
     def _query_token(self) -> dict[str, Any]:
         return {
             "access_token": "some_token",
@@ -17,11 +18,7 @@ class FakeAuth0AuthenticationSuccess(TokenProvider):
         }
 
 
-class FakeAuth0AuthenticationFailure(TokenProvider):
-    def __init__(self, *args: tuple, **kwargs: dict):
-        #   Only to raise an error as the Authentication is failed.
-        self._query_token()
-
+class FakeAuth0AuthenticationFailure(Auth0TokenProvider):
     def _query_token(self) -> dict[str, Any]:
         raise Auth0Error(
             status_code=403, error_code=403, message="Wrong email/password"


### PR DESCRIPTION
- Improve the `TokenProvider` abstraction. The `HTTPBearerAuthenticator` requires a `TokenProvider` and uses its `get_token` method, hence any valid `TokenProvider` should simply implement that method and not the `_query_token` method which is specific to some implementation of the token provider.
- Introduce  `ExpiringTokenProvider` abstract class in lieu of the old `TokenProvider` class
- Fix the token_provider check in the Client class. The previous implementation was bugged.
- Improve documentation formatting and fix the `CustomTokenProvider` authentication method example
